### PR TITLE
Minor change in plot recipes

### DIFF
--- a/src/plots_recipes.jl
+++ b/src/plots_recipes.jl
@@ -41,8 +41,8 @@ end
         nbins --> 500
 
         #title := "Detector Hits, XY"
-        xlabel := "x$length_ustring"
-        ylabel := "y$length_ustring"
+        xguide := "x$length_ustring"
+        yguide := "y$length_ustring"
 
         (pos_x, pos_y)
     end
@@ -56,8 +56,8 @@ end
         nbins --> 500
 
         #title := "Detector Hits, ZY"
-        xlabel := "z$length_ustring"
-        ylabel := "y$length_ustring"
+        xguide := "z$length_ustring"
+        yguide := "y$length_ustring"
 
         (pos_z, pos_y)
     end
@@ -71,8 +71,8 @@ end
         nbins --> 500
 
         # title := "Detector Hits, XZ"
-        xlabel := "x$length_ustring"
-        ylabel := "z$length_ustring"
+        xguide := "x$length_ustring"
+        yguide := "z$length_ustring"
 
         (pos_x, pos_z)
     end
@@ -88,8 +88,8 @@ end
         legend := false
 
         # title:="Energy Spectrum"
-        xlabel := "E $(ustring(edep_unit))"
-        ylabel := edep_unit == NoUnits ? "cts / E" : "cts / $edep_unit"
+        xguide := "E $(ustring(edep_unit))"
+        yguide := edep_unit == NoUnits ? "cts / E" : "cts / $edep_unit"
 
         ustrip.(sum.(events.edep))
     end
@@ -105,8 +105,8 @@ end
     if seriestype in (:line, :scatter)
         @series begin
             seriestype := seriestype
-            xlabel --> X_label
-            ylabel --> Y_label
+            xguide --> X_label
+            yguide --> Y_label
             (X, Y)
         end
 


### PR DESCRIPTION
Plotting an `RDWaveform` results in a warning that `xlabel` and `ylabel` might not lead to the expected behavior.

In fact, the axes labels cannot be overwritten within the plot command, see the last plot in the [SolidStateDetectors.jl tutorial](https://juliaphysics.github.io/SolidStateDetectors.jl/master/tutorial/):
```julia
p_pc_signal = plot( event.waveforms[1], lw = 1.5, xlims = (0, 1100), xlabel = "Time / ns",
                    legend = false, tickfontsize = 12, ylabel = "Energy / eV", guidefontsize = 14)

```
![Last_plot_tutorial](https://user-images.githubusercontent.com/30291312/97612438-b9e08080-1a17-11eb-884f-6c9dc4048531.png)

Updating the plot recipes will result in
![Last_plot_tutorial_new](https://user-images.githubusercontent.com/30291312/97612595-e8f6f200-1a17-11eb-898f-e1327c5d0c88.png)

Also, no warning will be shown when plotting a `RDWaveform`.

