### PR TITLE
Rename `RDWaveform` field `value` to `signal`

### DIFF
--- a/src/detector_waveforms.jl
+++ b/src/detector_waveforms.jl
@@ -35,7 +35,6 @@ export RDWaveform
 
 RDWaveform{T,U,TV,UV}(wf::RDWaveform) where {T,U,TV,UV} = RDWaveform{T,U,TV,UV}(wf.time, wf.signal)
 Base.convert(::Type{RDWaveform{T,U,TV,UV}}, wf::RDWaveform) where {T,U,TV,UV} = RDWaveform{T,U,TV,UV}(wf)
-Base.getproperty(wf::RDWaveform, sym::Symbol) = (sym == :value) ? wf.signal : Base.getfield(wf, sym)
 
 
 # ToDo: function for waveform duration. Use IntervalSets.duration?

--- a/src/detector_waveforms.jl
+++ b/src/detector_waveforms.jl
@@ -17,7 +17,7 @@ Represents a radiation detector signal waveform.
 Fields:
 
 * `time`: time axis, typically a range
-* `value`: sample values
+* `signal`: detector signal values
 
 Use [`ArrayOfRDWaveforms`](@ref) for arrays of `RDWaveform` that have a
 compact memory layout.
@@ -27,14 +27,15 @@ struct RDWaveform{
     TV<:TimeAxis{T},UV<:WaveformSamples{U},
 }
     time::TV
-    value::UV
+    signal::UV
 end
 
 export RDWaveform
 
 
-RDWaveform{T,U,TV,UV}(wf::RDWaveform) where {T,U,TV,UV} = RDWaveform{T,U,TV,UV}(wf.time, wf.value)
+RDWaveform{T,U,TV,UV}(wf::RDWaveform) where {T,U,TV,UV} = RDWaveform{T,U,TV,UV}(wf.time, wf.signal)
 Base.convert(::Type{RDWaveform{T,U,TV,UV}}, wf::RDWaveform) where {T,U,TV,UV} = RDWaveform{T,U,TV,UV}(wf)
+Base.getproperty(wf::RDWaveform, sym::Symbol) = (sym == :value) ? wf.signal : Base.getfield(wf, sym)
 
 
 # ToDo: function for waveform duration. Use IntervalSets.duration?
@@ -54,7 +55,7 @@ const ArrayOfRDWaveforms{
 } = StructArray{
     <:RDWaveform{T,U},
     N,
-    NamedTuple{(:time, :value), Tuple{VVT,VVU}}
+    NamedTuple{(:time, :signal), Tuple{VVT,VVU}}
 }
 
 export ArrayOfRDWaveforms
@@ -66,17 +67,17 @@ function StructArray{RDWaveform}(
         AbstractArray{<:AbstractVector{<:RealQuantity},N}
     }
 ) where {N}
-    time, value = contents
+    time, signal = contents
     VT = eltype(time)
-    VU = eltype(value)
+    VU = eltype(signal)
     T = eltype(VT)
     U = eltype(VU)
-    StructArray{RDWaveform{T,U,VT,VU}}((time, value))
+    StructArray{RDWaveform{T,U,VT,VU}}((time, signal))
 end
 
 
 StructArray{RDWaveform}(waveforms::AbstractVector{<:RDWaveform}) =
-    StructArray{RDWaveform}((map(w -> w.time, waveforms), VectorOfVectors(map(w -> w.value, waveforms))))
+    StructArray{RDWaveform}((map(w -> w.time, waveforms), VectorOfVectors(map(w -> w.signal, waveforms))))
 
 Base.convert(::Type{ArrayOfRDWaveforms}, waveforms::AbstractVector{<:RDWaveform}) = StructArray{RDWaveform}(waveforms)
 Base.convert(::Type{ArrayOfRDWaveforms}, waveforms::StructArray{<:RDWaveform}) = waveforms
@@ -88,7 +89,7 @@ Base.convert(::Type{StructArray{RDWaveform}}, waveforms::StructArray{<:RDWavefor
 # Specialize getindex to properly support ArraysOfArrays, preventing
 # conversion to exact element type:
 @inline Base.getindex(A::StructArray{<:RDWaveform}, I::Int...) =
-    RDWaveform(A.time[I...], A.value[I...])
+    RDWaveform(A.time[I...], A.signal[I...])
 
 
 @inline ArrayOfRDWaveforms(contents) = StructArray{RDWaveform}(contents)

--- a/src/plots_recipes.jl
+++ b/src/plots_recipes.jl
@@ -87,9 +87,9 @@ end
         @series begin
             seriestype := seriestype
             xguide --> "t"
-            yguide --> "sample value"
+            yguide --> "signal"
             unitformat --> :square
-            wf.time, wf.value
+            wf.time, wf.signal
         end
 
     #=

--- a/test/test_detector_waveforms.jl
+++ b/test/test_detector_waveforms.jl
@@ -15,8 +15,8 @@ using ArraysOfArrays, FillArrays, StructArrays, Unitful
     A = ArrayOfRDWaveforms((timedata, wfdata))
 
     @test A.time[1] == A[1].time == 0:0.1:12.7
-    @test A.value isa ArrayOfSimilarArrays
-    @test A.value[1] == A[1].value
+    @test A.signal isa ArrayOfSimilarArrays
+    @test A.signal[1] == A[1].signal
 end # testset
 
 @testset "detector_waveforms with units" begin
@@ -28,6 +28,6 @@ end # testset
     A = ArrayOfRDWaveforms((timedata, wfdata))
 
     @test A.time[1] == A[1].time == (0:0.1:12.7) * u"ns"
-    @test A.value isa ArrayOfSimilarArrays
-    @test A.value[1] == A[1].value
+    @test A.signal isa ArrayOfSimilarArrays
+    @test A.signal[1] == A[1].signal
 end # testset


### PR DESCRIPTION
This PR will rename the `RDWaveform` field `value` to `signal`, while still allowing for the field name `value` (for now).
I am not quite sure where to add `@deprecate` if applicable.