### PR TITLE
Overload `==` operator for `RDWaveform`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "RadiationDetectorSignals"
 uuid = "bf2c0563-65cf-5db2-a620-ceb7de82658c"
-version = "0.3.4"
+version = "0.3.5"
 
 [deps]
 ArraysOfArrays = "65a8f2f4-9b39-5baf-92e2-a9cc46fdf018"

--- a/src/detector_waveforms.jl
+++ b/src/detector_waveforms.jl
@@ -36,6 +36,9 @@ export RDWaveform
 RDWaveform{T,U,TV,UV}(wf::RDWaveform) where {T,U,TV,UV} = RDWaveform{T,U,TV,UV}(wf.time, wf.signal)
 Base.convert(::Type{RDWaveform{T,U,TV,UV}}, wf::RDWaveform) where {T,U,TV,UV} = RDWaveform{T,U,TV,UV}(wf)
 
+Base.:(==)(wf1::RDWaveform, wf2::RDWaveform) =
+    typeof(wf1) == typeof(wf2) && wf1.time == wf2.time && wf1.signal == wf2.signal
+
 Base.isapprox(a::RDWaveform, b::RDWaveform; kwargs...) = isapprox(a.time, b.time; kwargs...) && isapprox(a.signal, b.signal; kwargs...)
 
 Base.float(wf::RDWaveform) = RDWaveform(float(wf.time), float(wf.signal))

--- a/src/detector_waveforms.jl
+++ b/src/detector_waveforms.jl
@@ -36,9 +36,7 @@ export RDWaveform
 RDWaveform{T,U,TV,UV}(wf::RDWaveform) where {T,U,TV,UV} = RDWaveform{T,U,TV,UV}(wf.time, wf.signal)
 Base.convert(::Type{RDWaveform{T,U,TV,UV}}, wf::RDWaveform) where {T,U,TV,UV} = RDWaveform{T,U,TV,UV}(wf)
 
-Base.:(==)(wf1::RDWaveform, wf2::RDWaveform) =
-    typeof(wf1) == typeof(wf2) && wf1.time == wf2.time && wf1.signal == wf2.signal
-
+Base.:(==)(a::RDWaveform, b::RDWaveform) = a.time == b.time && a.signal == b.signal
 Base.isapprox(a::RDWaveform, b::RDWaveform; kwargs...) = isapprox(a.time, b.time; kwargs...) && isapprox(a.signal, b.signal; kwargs...)
 
 Base.float(wf::RDWaveform) = RDWaveform(float(wf.time), float(wf.signal))

--- a/test/test_detector_waveforms.jl
+++ b/test/test_detector_waveforms.jl
@@ -31,3 +31,23 @@ end # testset
     @test A.signal isa ArrayOfSimilarArrays
     @test A.signal[1] == A[1].signal
 end # testset
+
+@testset "detector_waveform equality" begin
+    wfdata = rand(128)
+    timedata = 0:0.1:12.7
+
+    wf1 = RDWaveform(wfdata, timedata)
+    wf2 = RDWaveform(reverse(wfdata),  timedata)
+    wf3 = RDWaveform(deepcopy(wfdata), timedata)
+
+    @test wf1 != wf2
+    @test wf1 == wf3
+
+    A = ArrayOfRDWaveforms([wf1, wf2])
+    B = ArrayOfRDWaveforms([wf1, wf3])
+    C = ArrayOfRDWaveforms([wf3, wf2])
+
+    @test A != B 
+    @test A == C
+end
+


### PR DESCRIPTION
Two identical `RDWaveforms` (same `signal` and `time`) would yield `false` when being compared using the `==` operator.
Overloading `==` results in the expected behaviour for `RDWaveform` and `ArrayOfRDWaveforms`

I also added tests for `==`.