### PR TITLE
Replace `RealQuantity` with `Unitful.RealOrRealQuantity`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,7 +27,7 @@ StatsBase = "0.33.7, 0.34"
 StructArrays = "0.4, 0.5, 0.6"
 Tables = "0.2, 1"
 TypedTables = "1.2"
-Unitful = "0.17, 0.18, 1"
+Unitful = "1.6"
 UnsafeArrays = "1"
 julia = "1.6"
 

--- a/src/RadiationDetectorSignals.jl
+++ b/src/RadiationDetectorSignals.jl
@@ -16,9 +16,10 @@ using TypedTables
 using UnsafeArrays
 using Unitful
 
+using Unitful: RealOrRealQuantity as RealQuantity
+
 import StatsBase
 
-include("numeric_types.jl")
 include("array_types.jl")
 include("detector_hits.jl")
 include("detector_waveforms.jl")

--- a/src/numeric_types.jl
+++ b/src/numeric_types.jl
@@ -1,8 +1,0 @@
-# This file is a part of RadiationDetectorSignals.jl, licensed under the MIT License (MIT).
-
-# TODO: Replace by true custom types to avoid type piracy on NamedTuple
-# (even though the named tuple types used here are quite specific).
-
-
-const MaybeWithUnits{T} = Union{T,Quantity{<:T}}
-const RealQuantity = MaybeWithUnits{<:Real}


### PR DESCRIPTION
Removes `MaybeWithUnits`, which was never exported or used in the code.